### PR TITLE
Fix installation into an empty environment.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-from intercom import VERSION
+VERSION = "0.2.7"
 
 setup(
     name="python-intercom",


### PR DESCRIPTION
This is a quick fix for installing python-intercom in an empty virtualenv. Without this change, it would fail because it was trying to import the requests package inside intercom/intercom.py before the installation was actually done.

I know that this pull request negates 17ad38086ed90c7644994d131c025107e5c3599c, but i think that being able to install the package is more important.

To properly fix this, the intercom/**init**.py file should be reorganized to avoid importing extra modules.
