### PR TITLE
User.delete() doesn't correct call the Intercom API.

### DIFF
--- a/intercom/intercom.py
+++ b/intercom/intercom.py
@@ -90,7 +90,7 @@ class Intercom(object):
             'User-Agent': 'python-intercom/' + __version__,
             'Accept': 'application/json'
         }
-        if method in ('POST', 'PUT'):
+        if method in ('POST', 'PUT', 'DELETE'):
             headers['content-type'] = 'application/json'
             req_params['data'] = json.dumps(params)
         elif method == 'GET':

--- a/tests/integration/test.py
+++ b/tests/integration/test.py
@@ -26,6 +26,10 @@ class IntegrationTest(TestCase):
         user = User.find(email='somebody@example.com')
         self.assertEqual('Somebody', user.name)
 
+    def test_delete_user(self):
+        user = User.delete(email="to-delete@example.com")
+        self.assertEqual("to-delete@example.com", user.email)
+
     @raises(ResourceNotFound)
     def test_not_found(self):
         User.find(email='not-found@example.com')


### PR DESCRIPTION
Hi,
Noticed in issue where calling User.delete() was not having the expected behavior (e.g. removing the user from Intercom!). 

Tracked it down the the following cause (I've tried my best to explain it, let me know if any of the points require further clarification!). 

Intercom._call was not expecting the DELETE method when constructing request data parameters. (line 93 in intercom/intercom.py) 
Hence, the params were being skipped over and the request didn't correctly register with Intercom's API.

Added in integration test to check this is working as intended..
Before, the user returned would be the 'bob@example.com' not the email specified ('to-delete@example.com' in the tests case).
Now, the user info returned corresponds to the email specified ('to-delete@example.com') as we would expect, as Intercom API '[Returns the deleted user on success](https://api.intercom.io/docs#deleting_a_user)' (as according to their docs).
