### PR TITLE
Use open() instead of file()

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ copyright = u'2013, John Keyes'
 # The short X.Y version.
 
 import re
-with file(os.path.join(path_dir, 'intercom', 'intercom.py')) as init:
+with open(os.path.join(path_dir, 'intercom', 'intercom.py')) as init:
     source = init.read()
     m = re.search("__version__ = '(\d+\.\d+\.\d+)'", source, re.M)
     version = m.groups()[0]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import re
 from setuptools import find_packages
 from setuptools import setup
 
-with file(os.path.join('intercom', 'intercom.py')) as init:
+with open(os.path.join('intercom', 'intercom.py')) as init:
     source = init.read()
     m = re.search("__version__ = '(\d+\.\d+\.\d+)'", source, re.M)
     __version__ = m.groups()[0]


### PR DESCRIPTION
From the [documentation](https://docs.python.org/release/2.7/library/functions.html#file):

> When opening a file, it’s preferable to use open() instead of invoking this constructor directly. file is more suited to type testing (for example, writing isinstance(f, file)).
