### PR TITLE
Raise error when API rate limit is exceeded.

### DIFF
--- a/intercom/intercom.py
+++ b/intercom/intercom.py
@@ -52,6 +52,11 @@ class ServerError(IntercomError):
     pass
 
 
+class ApiRateLimitExceededError(IntercomError):
+    """ Raised when the API rate limit is exceeded. """
+    pass
+
+
 class ServiceUnavailableError(IntercomError):
     """ Raised when the API cannot be handle a request. """
     pass
@@ -82,6 +87,8 @@ def raise_errors_on_failure(response):
         raise BadGatewayError("Bad gateway.")
     elif response.status_code == 503:
         raise ServiceUnavailableError("Service unavailable.")
+    elif response.status_code == 429:
+        raise ApiRateLimitExceededError("API rate limit exceeded.")
 
 
 class Intercom(object):
@@ -453,7 +460,7 @@ class Intercom(object):
             'event_name': event_name,
             'user_id': user_id,
             'email': email,
-            'created': int(time.time()) 
+            'created': int(time.time())
          }
 
         if isinstance(metadata, dict):

--- a/tests/integration/test.py
+++ b/tests/integration/test.py
@@ -183,6 +183,22 @@ def test_unreachable_endpoints():
         .should.throw(ServiceUnavailableError)
 
 
+@nottest
+@httpretty.activate
+def test_api_rate_limit_exceeded():
+    class ApiRateLimitExceededError(Exception):
+        pass
+    httpretty.register_uri(
+        get, r(r"example\.com"),
+        body=fixture('v1-user'), status=429)
+    Intercom.endpoints = ("http://example.com")
+    User.find.when.called_with(email='somebody@example.com')\
+        .should.throw(ApiRateLimitExceededError)
+    Intercom.endpoints = ("http://example.com", "http://api.example.com")
+    User.find.when.called_with(email='not-found@example.com')\
+        .should.throw(ApiRateLimitExceededError)
+
+
 @httpretty.activate
 @raises(ServiceUnavailableError)
 def test_unreachable():


### PR DESCRIPTION
As mentioned in API documentation of Intercom:
http://doc.intercom.io/api/#rate-limiting

This will raise `ApiRateLimitExceededError` if Intercom sends Too
many requests (429) response.

Also, will it be helpful if we attach HTTP response to `ApiRateLimitExceededError` ?