### PR TITLE
Fix documentation for updating tags.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -137,8 +137,10 @@ Intercom documentation: `Updating a Tag <http://doc.intercom.io/api/v1/#update-a
 ::
 
     from intercom import Tag
-    tag = Tag.update("Free Trial", "tag",
-        user_ids=["abc123", "def456"])
+    tag = Tag.find_by_name("Free Trial")
+    tag.user_ids = ["abc123", "def456"]
+    tag.tag_or_untag = "tag"
+    tag.save()
 
 
 Impressions


### PR DESCRIPTION
Trying to use the method documented does not work; Tag inherits
from dict and defines no 'update' method of its own, resulting in
a stack trace like:

➜  ~  python tag.py
Traceback (most recent call last):
  File tag.py, line 15, in <module>
    emails=list(emails))
TypeError: descriptor 'update' requires a 'dict' object but received a 'str'