### PR TITLE
Allow values of custom attributes to be None.

### DIFF
--- a/intercom/lib/flat_store.py
+++ b/intercom/lib/flat_store.py
@@ -12,7 +12,8 @@ class FlatStore(dict):
     def __setitem__(self, key, value):
         if not (
             isinstance(value, numbers.Real) or
-            isinstance(value, six.string_types)
+            isinstance(value, six.string_types) or
+            value is None
         ):
             raise ValueError(
                 "custom data only allows string and real number values")


### PR DESCRIPTION
Hi,

I have ``None`` values in custom attributes of a company in Intercom (named 'UNKNOWN' in Intercom). Trying to find or create a company (e.g. ``Company. find(company_id='bla'``) gives a ValueError, complaining that custom data can only be numbers or strings. Afaik, Intercom does simply not allow nested values (and I guess that is what the flat_store functionality is supposed to be for).

This PR is to also allow null values in custom attributes. Unittests pass, and I have no problems with interacting with intercom using Nones.