### PR TITLE
fixing none error

### DIFF
--- a/intercom/lib/flat_store.py
+++ b/intercom/lib/flat_store.py
@@ -10,7 +10,7 @@ class FlatStore(dict):
         self.update(*args, **kwargs)
 
     def __setitem__(self, key, value):
-        if not (
+        if value is not None and not (
             isinstance(value, numbers.Real) or
             isinstance(value, six.string_types)
         ):

--- a/intercom/request.py
+++ b/intercom/request.py
@@ -43,9 +43,9 @@ class Request(object):
     def parse_body(cls, resp):
         try:
             # use supplied encoding to decode the response content
-            decoded_body = resp.content.decode(resp.encoding)
-            if not decoded_body:  # return early for empty responses (issue-72)
+            if not resp.content or resp.content == ' ':  # return early for empty responses (issue-72)
                 return
+            decoded_body = resp.content.decode(resp.encoding)
             body = json.loads(decoded_body)
             if body.get('type') == 'error.list':
                 cls.raise_application_errors_on_failure(body, resp.status_code)


### PR DESCRIPTION
There is an issue that intercom sometimes spits NONE in response. Flatstorage is dict instance, so will survive none. 