### PR TITLE
Bugfix: use apparent_encoding if encoding is set to None

### DIFF
--- a/intercom/lib/flat_store.py
+++ b/intercom/lib/flat_store.py
@@ -12,7 +12,8 @@ class FlatStore(dict):
     def __setitem__(self, key, value):
         if not (
             isinstance(value, numbers.Real) or
-            isinstance(value, six.string_types)
+            isinstance(value, six.string_types) or
+            value is None
         ):
             raise ValueError(
                 "custom data only allows string and real number values")

--- a/intercom/request.py
+++ b/intercom/request.py
@@ -42,10 +42,13 @@ class Request(object):
     @classmethod
     def parse_body(cls, resp):
         try:
-            # use supplied encoding to decode the response content
-            decoded_body = resp.content.decode(resp.encoding)
-            if not decoded_body:  # return early for empty responses (issue-72)
+            # return early for empty responses (issue-72)
+            if not resp.content or not resp.content.strip():
                 return
+            # use supplied encoding to decode the response content
+            decoded_body = resp.content.decode(
+                resp.encoding or resp.apparent_encoding
+            )
             body = json.loads(decoded_body)
             if body.get('type') == 'error.list':
                 cls.raise_application_errors_on_failure(body, resp.status_code)


### PR DESCRIPTION
Defeat value for encoding attribute in class `requests.Response` is `None`. If server doesn't set it to something useful (ie on 202 responses) it remains `None` and gets passed to `decode()` and thus fails. Class `requests. Response` has very nice fallback, apparent_encoding, that is provided by the chardet library and can come in handy here.