### PR TITLE
Add interface support for opens, closes, and assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,12 @@ conversation.reply(
 conversation.reply(
     type='admin', email='bob@example.com',
     message_type='comment', body='bar')
+# Admin (identified by id) opens a conversation
+conversation.open_conversation(admin_id=7)
+# Admin (identified by id) closes a conversation
+conversation.close_conversation(admin_id=7)
+# Admin (identified by id) assigns a conversation to an assignee
+conversation.assign(assignee_id=8, admin_id=7)
 
 # MARKING A CONVERSATION AS READ
 conversation.read = True

--- a/intercom/extended_api_operations/reply.py
+++ b/intercom/extended_api_operations/reply.py
@@ -6,6 +6,24 @@ from intercom import utils
 class Reply(object):
 
     def reply(self, **reply_data):
+        return self.__reply(reply_data)
+
+    def close_conversation(self, **reply_data):
+        reply_data['type'] = 'admin'
+        reply_data['message_type'] = 'close'
+        return self.__reply(reply_data)
+
+    def open_conversation(self, **reply_data):
+        reply_data['type'] = 'admin'
+        reply_data['message_type'] = 'open'
+        return self.__reply(reply_data)
+
+    def assign(self, **reply_data):
+        reply_data['type'] = 'admin'
+        reply_data['message_type'] = 'assignment'
+        return self.__reply(reply_data)
+
+    def __reply(self, reply_data):
         from intercom import Intercom
         collection = utils.resource_class_to_collection_name(self.__class__)
         url = "/%s/%s/reply" % (collection, self.id)

--- a/tests/integration/test_conversations.py
+++ b/tests/integration/test_conversations.py
@@ -110,7 +110,8 @@ class ConversationTest(unittest.TestCase):
             # There is a part_type
             self.assertIsNotNone(part.part_type)
             # There is a body
-            self.assertIsNotNone(part.body)
+            if not part.part_type == 'assignment':
+                self.assertIsNotNone(part.body)
 
     def test_reply(self):
         # REPLYING TO CONVERSATIONS
@@ -126,6 +127,32 @@ class ConversationTest(unittest.TestCase):
             message_type='comment', body='bar')
         conversation = Conversation.find(id=self.admin_conv.id)
         self.assertEqual(num_parts + 2, len(conversation.conversation_parts))
+
+    def test_open(self):
+        # OPENING CONVERSATIONS
+        conversation = Conversation.find(id=self.admin_conv.id)
+        conversation.close_conversation(admin_id=self.admin.id, body='Closing message')
+        self.assertFalse(conversation.open)
+        conversation.open_conversation(admin_id=self.admin.id, body='Opening message')
+        conversation = Conversation.find(id=self.admin_conv.id)
+        self.assertTrue(conversation.open)
+
+    def test_close(self):
+        # CLOSING CONVERSATIONS
+        conversation = Conversation.find(id=self.admin_conv.id)
+        self.assertTrue(conversation.open)
+        conversation.close_conversation(admin_id=self.admin.id, body='Closing message')
+        conversation = Conversation.find(id=self.admin_conv.id)
+        self.assertFalse(conversation.open)
+
+    def test_assignment(self):
+        # ASSIGNING CONVERSATIONS
+        conversation = Conversation.find(id=self.admin_conv.id)
+        num_parts = len(conversation.conversation_parts)
+        conversation.assign(assignee_id=self.admin.id, admin_id=self.admin.id)
+        conversation = Conversation.find(id=self.admin_conv.id)
+        self.assertEqual(num_parts + 1, len(conversation.conversation_parts))
+        self.assertEqual("assignment", conversation.conversation_parts[-1].part_type)
 
     def test_mark_read(self):
         # MARKING A CONVERSATION AS READ


### PR DESCRIPTION
We recently added support for assigning, opening, and closing conversations: https://doc.intercom.io/api/#replying-to-a-conversation

We've also released updated versions of the Go, Java, Ruby, and PHP libraries. Be good to get nice support in here too!