### PR TITLE
Add python classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,12 @@ setup(
     license="MIT License",
     url="http://github.com/jkeyes/python-intercom",
     keywords='Intercom crm python',
-    classifiers=[],
+    classifiers=[
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+    ],
     packages=find_packages(),
     include_package_data=True,
     install_requires=["requests", "inflection", "certifi", "six"],


### PR DESCRIPTION
I used [Can I Use Python 3?](https://caniusepython3.com/) today to check my projects compatibility with Python 3, and it incorrectly listed python-intercom as a package that doesn't support Python 3. That's because it doesn't have classifiers on PyPI. This fixes that.