### PR TITLE
Add a resource for the contacts endpoint

### DIFF
--- a/intercom/__init__.py
+++ b/intercom/__init__.py
@@ -10,6 +10,7 @@ from .request import Request
 from .admin import Admin  # noqa
 from .company import Company  # noqa
 from .count import Count  # noqa
+from .contact import Contact  # noqa
 from .conversation import Conversation  # noqa
 from .event import Event  # noqa
 from .message import Message  # noqa

--- a/intercom/contact.py
+++ b/intercom/contact.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+from intercom.api_operations.all import All
+from intercom.api_operations.count import Count
+from intercom.api_operations.delete import Delete
+from intercom.api_operations.find import Find
+from intercom.api_operations.find_all import FindAll
+from intercom.api_operations.load import Load
+from intercom.api_operations.save import Save
+from intercom.traits.api_resource import Resource
+from intercom.traits.incrementable_attributes import IncrementableAttributes
+
+
+class Contact(Resource, Find, FindAll, All, Count, Load, Save, Delete,
+              IncrementableAttributes):
+
+    identity_vars = ['email']
+
+    @property
+    def flat_store_attributes(self):
+        return ['custom_attributes']

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -45,9 +45,9 @@ def mock_response(content, status_code=200, encoding='utf-8', headers=None):
         content=content, status_code=status_code, encoding=encoding, headers=headers)
 
 
-def get_user(email="bob@example.com", name="Joe Schmoe"):
+def get_user_or_contact(type, email, name):
     return {
-        "type": "user",
+        "type": type,
         "id": "aaaaaaaaaaaaaaaaaaaaaaaa",
         "user_id": 'id-from-customers-app',
         "email": email,
@@ -57,7 +57,6 @@ def get_user(email="bob@example.com", name="Joe Schmoe"):
             "image_url": "https://graph.facebook.com/1/picture?width=24&height=24"
         },
         "app_id": "the-app-id",
-        "created_at": 1323422442,
         "custom_attributes": {"a": "b", "b": 2},
         "companies": {
             "type": "company.list",
@@ -82,7 +81,6 @@ def get_user(email="bob@example.com", name="Joe Schmoe"):
                 }
             ]
         },
-        "session_count": 123,
         "unsubscribed_from_emails": True,
         "last_request_at": 1401970113,
         "created_at": 1401970114,
@@ -135,6 +133,16 @@ def get_user(email="bob@example.com", name="Joe Schmoe"):
             "country_code": "IRL"
         }
     }
+
+
+def get_user(email="bob@example.com", name="Joe Schmoe"):
+    user = get_user_or_contact('user', email, name)
+    user.update({"session_count": 123})
+    return user
+
+
+def get_contact(email="bob@example.com", name="Joe Schmoe"):
+    return get_user_or_contact('contact', email, name)
 
 
 def page_of_users(include_next_link=False):

--- a/tests/unit/test_contact.py
+++ b/tests/unit/test_contact.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+
+import mock
+import time
+import unittest
+
+from datetime import datetime
+from intercom import Intercom
+from intercom import Contact
+from mock import patch
+from nose.tools import istest
+from nose.tools import eq_
+from nose.tools import ok_
+from tests.unit import get_contact
+
+
+class ContactTest(unittest.TestCase):
+    """
+    Contacts are so similar to users that we only perform some basic coverage
+    """
+    @istest
+    def it_to_dict_itself(self):
+        created_at = datetime.utcnow()
+        contact = Contact(
+            email="jim@example.com", user_id="12345",
+            created_at=created_at, name="Jim Bob")
+        as_dict = contact.to_dict
+        eq_(as_dict["email"], "jim@example.com")
+        ok_(as_dict["user_id"])
+        eq_(as_dict["created_at"], time.mktime(created_at.timetuple()))
+        eq_(as_dict["name"], "Jim Bob")
+
+    @istest
+    def it_allows_update_last_request_at(self):
+        payload = {
+            'user_id': '1224242',
+            'update_last_request_at': True,
+            'custom_attributes': {}
+        }
+        with patch.object(Intercom, 'post', return_value=payload) as mock_method:
+            Contact.create(update_last_request_at=True)
+            mock_method.assert_called_once_with(
+                '/contacts/', update_last_request_at=True)
+
+    @istest
+    def it_fetches_a_contact(self):
+        with patch.object(Intercom, 'get', return_value=get_contact()) as mock_method:  # noqa
+            contact = Contact.find(email='somebody@example.com')
+            eq_(contact.email, 'bob@example.com')
+            eq_(contact.name, 'Joe Schmoe')
+            mock_method.assert_called_once_with('/contacts', email='somebody@example.com')  # noqa
+
+    @istest
+    # @httpretty.activate
+    def it_saves_a_contact_always_sends_custom_attributes(self):
+        contact = Contact(email="jo@example.com")
+
+        body = {
+            'email': 'jo@example.com',
+            'user_id': 'i-1224242',
+            'custom_attributes': {}
+        }
+
+        with patch.object(Intercom, 'post', return_value=body) as mock_method:
+            contact.save()
+            eq_(contact.email, 'jo@example.com')
+            eq_(contact.custom_attributes, {})
+            mock_method.assert_called_once_with(
+                '/contacts',
+                email="jo@example.com",
+                custom_attributes={})
+
+    @istest
+    def it_can_save_a_contact_with_a_none_email(self):
+        contact = Contact(
+            email=None,
+            companies=[{'company_id': 6, 'name': 'Intercom'}])
+        body = {
+            'custom_attributes': {},
+            'email': None,
+            'user_id': 'i-1224242',
+            'companies': [{
+                'company_id': 6,
+                'name': 'Intercom'
+            }]
+        }
+        with patch.object(Intercom, 'post', return_value=body) as mock_method:
+            contact.save()
+            ok_(contact.email is None)
+            eq_(contact.user_id, 'i-1224242')
+            mock_method.assert_called_once_with(
+                '/contacts',
+                email=None,
+                companies=[{'company_id': 6, 'name': 'Intercom'}],
+                custom_attributes={})
+
+    @istest
+    def it_deletes_a_contact(self):
+        contact = Contact(id="1")
+        with patch.object(Intercom, 'delete', return_value={}) as mock_method:
+            contact = contact.delete()
+            eq_(contact.id, "1")
+            mock_method.assert_called_once_with('/contacts/1/')
+
+    @istest
+    def it_returns_the_total_number_of_contacts(self):
+        with mock.patch.object(Contact, 'count') as mock_count:
+            mock_count.return_value = 100
+            eq_(100, Contact.count())


### PR DESCRIPTION
(now called leads, but still contacts in the API)

Contacts are extremely similar to users. The main difference is that the user_id cannot be specified, it must be auto-assigned by Intercom. There are also a few properties that Users have but Contacts do not.

This creates the new resource, adds some tests for it, and does a minor refactor in the test utilities to make it easy to generate a contact payload without duplicating a whole bunch of code. I also noticed that the created_at field was specified twice in get_user(), so I removed the first instance (which was being ignored).