### PR TITLE
Change `id` to `user_id` in user creation example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,7 +47,7 @@ Intercom documentation: `Create or Update Users <https://doc.intercom.io/api/#cr
 ::
 
     from intercom import User
-    User.create(id='1234', email='bob@example.com')
+    User.create(user_id='1234', email='bob@example.com')
 
 Updating the Last Seen Time
 +++++++++++++++++++++++++++


### PR DESCRIPTION
Creating a user with the `id` parameter as currently shown in the API does not actually save the input value - the `id` parameter is assigned by intercom and is not mutable. The documentation should instead use `user_id` in it's user creation example.
