### PR TITLE
Use Personal Access Token authentication

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,10 +35,9 @@ Configure your client
 .. code:: python
 
     from intercom.client import Client
-    intercom = Client(app_id='my_app_id', api_key='my_api_key')
+    intercom = Client(personal_access_token='my_personal_access_token')
 
-You can get your app_id from the URL when you're logged into Intercom (it's the alphanumeric just after /apps/) and your API key from the API keys integration settings page (under your app settings - integrations in Intercom).
-
+Note that certain resources will require an extended scope access token : `Setting up Personal Access Tokens <https://developers.intercom.com/docs/personal-access-tokens>`_
 
 Resources
 ~~~~~~~~~
@@ -552,7 +551,7 @@ Integration tests:
 
 .. code:: bash
 
-    INTERCOM_APP_ID=xxx INTERCOM_APP_API_KEY=xxx nosetests tests/integration
+    INTERCOM_PERSONAL_ACCESS_TOKEN=xxx nosetests tests/integration
 
 .. |PyPI Version| image:: https://img.shields.io/pypi/v/python-intercom.svg
    :target: https://pypi.python.org/pypi/python-intercom

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -15,7 +15,7 @@ Run the integration tests:
 ::
 
     # THESE SHOULD ONLY BE RUN ON A TEST APP!
-    INTERCOM_APP_ID=xxx INTERCOM_APP_API_KEY=xxx nosetests tests/integration
+    INTERCOM_PERSONAL_ACCESS_TOKEN=xxx nosetests tests/integration
 
 Generate the Documentation
 --------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,13 +28,12 @@ Usage
 Authentication
 ---------------
 
-Intercom documentation: `Authentication <http://api.intercom.io/docs#authentication>`_.
+Intercom documentation: `Authentication <https://developers.intercom.com/docs#authentication>`_.
 
 ::
 
-    from intercom import Intercom
-    Intercom.app_id = 'dummy-app-id'
-    Intercom.app_api_key = 'dummy-api-key'
+    from intercom.client import Client
+    intercom = Client(personal_access_token='my_personal_access_token')
 
 Users
 -----

--- a/intercom/client.py
+++ b/intercom/client.py
@@ -3,15 +3,14 @@
 
 class Client(object):
 
-    def __init__(self, app_id='my_app_id', api_key='my_api_key'):
-        self.app_id = app_id
-        self.api_key = api_key
+    def __init__(self, personal_access_token='my_personal_access_token'):
+        self.personal_access_token = personal_access_token
         self.base_url = 'https://api.intercom.io'
         self.rate_limit_details = {}
 
     @property
     def _auth(self):
-        return (self.app_id, self.api_key)
+        return (self.personal_access_token, '')
 
     @property
     def admins(self):

--- a/tests/integration/issues/test_72.py
+++ b/tests/integration/issues/test_72.py
@@ -7,8 +7,7 @@ import time
 from intercom.client import Client
 
 intercom = Client(
-    os.environ.get('INTERCOM_APP_ID'),
-    os.environ.get('INTERCOM_API_KEY'))
+    os.environ.get('INTERCOM_PERSONAL_ACCESS_TOKEN'))
 
 
 class Issue72Test(unittest.TestCase):

--- a/tests/integration/issues/test_73.py
+++ b/tests/integration/issues/test_73.py
@@ -9,8 +9,7 @@ import unittest
 from intercom.client import Client
 
 intercom = Client(
-    os.environ.get('INTERCOM_APP_ID'),
-    os.environ.get('INTERCOM_API_KEY'))
+    os.environ.get('INTERCOM_PERSONAL_ACCESS_TOKEN'))
 
 
 class Issue73Test(unittest.TestCase):

--- a/tests/integration/test_admin.py
+++ b/tests/integration/test_admin.py
@@ -5,8 +5,7 @@ import unittest
 from intercom.client import Client
 
 intercom = Client(
-    os.environ.get('INTERCOM_APP_ID'),
-    os.environ.get('INTERCOM_API_KEY'))
+    os.environ.get('INTERCOM_PERSONAL_ACCESS_TOKEN'))
 
 
 class AdminTest(unittest.TestCase):

--- a/tests/integration/test_company.py
+++ b/tests/integration/test_company.py
@@ -10,8 +10,7 @@ from . import get_or_create_company
 from . import get_timestamp
 
 intercom = Client(
-    os.environ.get('INTERCOM_APP_ID'),
-    os.environ.get('INTERCOM_API_KEY'))
+    os.environ.get('INTERCOM_PERSONAL_ACCESS_TOKEN'))
 
 
 class CompanyTest(unittest.TestCase):

--- a/tests/integration/test_conversations.py
+++ b/tests/integration/test_conversations.py
@@ -11,8 +11,7 @@ from . import get_or_create_user
 from . import get_timestamp
 
 intercom = Client(
-    os.environ.get('INTERCOM_APP_ID'),
-    os.environ.get('INTERCOM_API_KEY'))
+    os.environ.get('INTERCOM_PERSONAL_ACCESS_TOKEN'))
 
 
 class ConversationTest(unittest.TestCase):

--- a/tests/integration/test_notes.py
+++ b/tests/integration/test_notes.py
@@ -8,8 +8,7 @@ from . import get_or_create_user
 from . import get_timestamp
 
 intercom = Client(
-    os.environ.get('INTERCOM_APP_ID'),
-    os.environ.get('INTERCOM_API_KEY'))
+    os.environ.get('INTERCOM_PERSONAL_ACCESS_TOKEN'))
 
 
 class NoteTest(unittest.TestCase):

--- a/tests/integration/test_segments.py
+++ b/tests/integration/test_segments.py
@@ -5,8 +5,7 @@ import unittest
 from intercom.client import Client
 
 intercom = Client(
-    os.environ.get('INTERCOM_APP_ID'),
-    os.environ.get('INTERCOM_API_KEY'))
+    os.environ.get('INTERCOM_PERSONAL_ACCESS_TOKEN'))
 
 
 class SegmentTest(unittest.TestCase):

--- a/tests/integration/test_tags.py
+++ b/tests/integration/test_tags.py
@@ -10,8 +10,7 @@ from . import get_or_create_user
 from . import get_timestamp
 
 intercom = Client(
-    os.environ.get('INTERCOM_APP_ID'),
-    os.environ.get('INTERCOM_API_KEY'))
+    os.environ.get('INTERCOM_PERSONAL_ACCESS_TOKEN'))
 
 
 class TagTest(unittest.TestCase):

--- a/tests/integration/test_user.py
+++ b/tests/integration/test_user.py
@@ -8,8 +8,7 @@ from . import get_or_create_user
 from . import delete_user
 
 intercom = Client(
-    os.environ.get('INTERCOM_APP_ID'),
-    os.environ.get('INTERCOM_API_KEY'))
+    os.environ.get('INTERCOM_PERSONAL_ACCESS_TOKEN'))
 
 
 class UserTest(unittest.TestCase):


### PR DESCRIPTION
Minor changes to support PAT : API Keys are currently deprecated and will be removed in January 2017 ([Setting up Personal Access Tokens](https://developers.intercom.com/docs/personal-access-tokens))
