### PR TITLE
Fix connection errors when paginating -- fixes #120

### DIFF
--- a/intercom/collection_proxy.py
+++ b/intercom/collection_proxy.py
@@ -98,4 +98,6 @@ class CollectionProxy(six.Iterator):
     def extract_next_link(self, response):
         if self.paging_info_present(response):
             paging_info = response["pages"]
-            return paging_info["next"]
+            if paging_info["next"]:
+                next_parsed = six.moves.urllib.parse.urlparse(paging_info["next"])
+                return '{}?{}'.format(next_parsed.path, next_parsed.query)

--- a/tests/unit/test_collection_proxy.py
+++ b/tests/unit/test_collection_proxy.py
@@ -30,7 +30,7 @@ class CollectionProxyTest(unittest.TestCase):
         side_effect = [page1, page2]
         with patch.object(Client, 'get', side_effect=side_effect) as mock_method:  # noqa
             emails = [user.email for user in self.client.users.all()]
-            eq_([call('/users', {}), call('https://api.intercom.io/users?per_page=50&page=2', {})],  # noqa
+            eq_([call('/users', {}), call('/users?per_page=50&page=2', {})],  # noqa
                 mock_method.mock_calls)
             eq_(emails, ['user1@example.com', 'user2@example.com', 'user3@example.com'] * 2)  # noqa
 


### PR DESCRIPTION
Solution to #120 provided in #121 does not pass travis tests, so I'm opening this. It uses `six` to get `urlparse` from the right location.