### PR TITLE
Adding missing `find_all` capability to event resources

### DIFF
--- a/intercom/api_operations/find_all.py
+++ b/intercom/api_operations/find_all.py
@@ -8,6 +8,8 @@ from intercom.collection_proxy import CollectionProxy
 class FindAll(object):
     """A mixin that provides `find_all` functionality."""
 
+    proxy_class = CollectionProxy
+
     def find_all(self, **params):
         """Find all instances of the resource based on the supplied parameters."""
         collection = utils.resource_class_to_collection_name(
@@ -17,6 +19,6 @@ class FindAll(object):
         else:
             finder_url = "/%s" % (collection)
         finder_params = params
-        return CollectionProxy(
+        return self.proxy_class(
             self.client, self.collection_class, collection,
             finder_url, finder_params)

--- a/intercom/service/event.py
+++ b/intercom/service/event.py
@@ -3,10 +3,20 @@
 from intercom import event
 from intercom.api_operations.bulk import Submit
 from intercom.api_operations.save import Save
+from intercom.api_operations.find_all import FindAll
 from intercom.service.base_service import BaseService
+from intercom.collection_proxy import CollectionProxy
 
 
-class Event(BaseService, Save, Submit):
+class EventCollectionProxy(CollectionProxy):
+
+    def paging_info_present(self, response):
+        return 'pages' in response and 'next' in response['pages']
+
+
+class Event(BaseService, Save, Submit, FindAll):
+
+    proxy_class = EventCollectionProxy
 
     @property
     def collection_class(self):


### PR DESCRIPTION
It seems that `find_all()` was missing from `intercom.events`. In order to add it, I had to introduce a slightly different paging behavior (not sure why this API inconsistency). 

The least obtrusive way I found to do this was to allow overriding the `CollectionProxy` class for `FindAll` and to create a dedicated `CollectionProxy` subclass for events which overrides `paging_info_present`. 

It works well for me, I hope that for others this will be useful as well. 