### PR TITLE
3.0.5 Increasing default request timeout.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,7 @@
 Changelog
 =========
+* 3.0.5
+   * Increased default request timeout to 90 seconds. This can also be set by the `INTERCOM_REQUEST_TIMEOUT` environment variable. (`#154 <https://github.com/jkeyes/python-intercom/pull/154>`_)
 * 3.0.4
    * Added `resource_type` attribute to lightweight classes. (`#153 <https://github.com/jkeyes/python-intercom/pull/153>`_)
 * 3.0.3

--- a/intercom/__init__.py
+++ b/intercom/__init__.py
@@ -6,7 +6,7 @@ from .errors import (ArgumentError, AuthenticationError, # noqa
     MultipleMatchingUsersError, RateLimitExceeded, ResourceNotFound,
     ServerError, ServiceUnavailableError, UnexpectedError, TokenUnauthorizedError)
 
-__version__ = '3.0.4'
+__version__ = '3.0.5'
 
 
 RELATED_DOCS_TEXT = "See https://github.com/jkeyes/python-intercom \

--- a/intercom/request.py
+++ b/intercom/request.py
@@ -7,20 +7,30 @@ from pytz import utc
 import certifi
 import json
 import logging
+import os
 import requests
 
 logger = logging.getLogger('intercom.request')
 
 
+def configure_timeout():
+    """Configure the request timeout."""
+    timeout = os.getenv('INTERCOM_REQUEST_TIMEOUT', '90')
+    try:
+        return int(timeout)
+    except ValueError:
+        logger.warning('%s is not a valid timeout value.', timeout)
+    return 90
+
+
 class Request(object):
 
-    timeout = 10
+    timeout = configure_timeout()
 
     def __init__(self, http_method, path, http_session=None):
         self.http_method = http_method
         self.path = path
         self.http_session = http_session
-
 
     def execute(self, base_url, auth, params):
         return self.send_request_to_path(base_url, auth, params)

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -332,6 +332,25 @@ class RequestTest(unittest.TestCase):
     @istest
     def it_allows_the_timeout_to_be_changed(self):
         from intercom.request import Request
-        eq_(10, Request.timeout)
-        Request.timeout = 3
-        eq_(3, Request.timeout)
+        try:
+            eq_(90, Request.timeout)
+            Request.timeout = 3
+            eq_(3, Request.timeout)
+        finally:
+            Request.timeout = 90
+
+    @istest
+    def it_allows_the_timeout_to_be_configured(self):
+        import os
+        from intercom.request import configure_timeout
+
+        # check the default
+        eq_(90, configure_timeout())
+
+        # override the default
+        os.environ['INTERCOM_REQUEST_TIMEOUT'] = '20'
+        eq_(20, configure_timeout())
+
+        # ignore bad timeouts, reset to default 90
+        os.environ['INTERCOM_REQUEST_TIMEOUT'] = 'abc'
+        eq_(90, configure_timeout())


### PR DESCRIPTION
Increased default request timeout to 90 seconds. This can also be set by the `INTERCOM_REQUEST_TIMEOUT` environment variable. 