### PR TITLE
Fix TypeError when incrementing a None value

### DIFF
--- a/intercom/traits/incrementable_attributes.py
+++ b/intercom/traits/incrementable_attributes.py
@@ -5,4 +5,6 @@ class IncrementableAttributes(object):
 
     def increment(self, key, value=1):
         existing_value = self.custom_attributes.get(key, 0)
+        if existing_value is None:
+            existing_value = 0
         self.custom_attributes[key] = existing_value + value

--- a/tests/integration/test_user.py
+++ b/tests/integration/test_user.py
@@ -57,6 +57,10 @@ class UserTest(unittest.TestCase):
         user.increment('karma')
         intercom.users.save(user)
         self.assertEqual(user.custom_attributes["karma"], karma + 2)
+        user.custom_attributes['logins'] = None
+        user.increment('logins')
+        intercom.users.save(user)
+        self.assertEqual(user.custom_attributes['logins'], 1)
 
     def test_iterate(self):
         # Iterate over all users

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -405,7 +405,8 @@ class DescribeIncrementingCustomAttributeFields(unittest.TestCase):
                 'mad': 123,
                 'another': 432,
                 'other': time.mktime(created_at.timetuple()),
-                'thing': 'yay'
+                'thing': 'yay',
+                'logins': None,
             }
         }
         self.user = User(**params)
@@ -429,6 +430,11 @@ class DescribeIncrementingCustomAttributeFields(unittest.TestCase):
     def it_can_increment_new_custom_data_fields(self):
         self.user.increment('new_field', 3)
         eq_(self.user.to_dict()['custom_attributes']['new_field'], 3)
+
+    @istest
+    def it_can_increment_none_values(self):
+        self.user.increment('logins')
+        eq_(self.user.to_dict()['custom_attributes']['logins'], 1)
 
     @istest
     def it_can_call_increment_on_the_same_key_twice_and_increment_by_2(self):  # noqa


### PR DESCRIPTION
Code like this:

```python
intercom_user.increment('logins')
```

Can throw a `TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'` if logins has a `None` value.

As the increment code already assumes that a missing key should be treated as zero, I don't think it's that much of a stretch to extend this to `None` values.