### PR TITLE
find admin by id fixes #159

### DIFF
--- a/intercom/service/admin.py
+++ b/intercom/service/admin.py
@@ -2,10 +2,11 @@
 
 from intercom import admin
 from intercom.api_operations.all import All
+from intercom.api_operations.find import Find
 from intercom.service.base_service import BaseService
 
 
-class Admin(BaseService, All):
+class Admin(BaseService, All, Find):
 
     @property
     def collection_class(self):


### PR DESCRIPTION
So far, there is only the method ` intercom.admins.all()` to list all admins.
But Intercom also offers to find an admin by ID.

Use it like this:
`admin =  intercom.admins.find(id='12345')`