### PR TITLE
Fix Travis build, remove pip-incompatible option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
   - 2.7
   - 3.4
 install: 
-  - pip install -r requirements.txt --use-mirrors
-  - pip install -r dev-requirements.txt --use-mirrors
+  - pip install -r requirements.txt
+  - pip install -r dev-requirements.txt
 script:
   - nosetests --with-coverag tests/unit
 after_success:


### PR DESCRIPTION
As of pip 7.0.0, `--use-mirrors` is deprecated.
This was making Travis fail to start.


https://pip.pypa.io/en/stable/news/
```
7.0.0 (2015-05-21)
BACKWARD INCOMPATIBLE Removed the deprecated --mirror, --use-mirrors, and -M options.
```