### PR TITLE
Add waiting_since to timestamp fields

### DIFF
--- a/intercom/traits/api_resource.py
+++ b/intercom/traits/api_resource.py
@@ -14,7 +14,7 @@ def type_field(attribute):
 
 
 def timestamp_field(attribute):
-    return attribute.endswith('_at')
+    return attribute.endswith('_at') or attribute == "waiting_since"
 
 
 def custom_attribute_field(attribute):


### PR DESCRIPTION
The /conversations endpoint also has a `waiting_since` field as timestamp ([link to API ref](https://developers.intercom.com/v2.0/reference#conversation-model))